### PR TITLE
Fix typo in MouseController comment

### DIFF
--- a/src/js/content/MouseController.js
+++ b/src/js/content/MouseController.js
@@ -24,7 +24,7 @@ function MouseController() {
         doc.removeEventListener('mousemove', mouseMoveCallback);
     }
     /*
-     * Interal use
+     * Internal use
      */
     function mouseMoveCallback(event) {
         mMoved = true;


### PR DESCRIPTION
## Summary
- correct a comment typo in MouseController.js

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409ee9cc788320b16e5c7c5babaab8